### PR TITLE
Allocating 0-length buffers

### DIFF
--- a/unix/io_page.ml
+++ b/unix/io_page.ml
@@ -27,8 +27,10 @@ let length t = Array1.dim t
 external alloc_pages: int -> t = "caml_alloc_pages"
 
 let get n =
-  if n < 1
-  then raise (Invalid_argument "The number of page should be greater or equal to 1")
+  if n < 0
+  then raise (Invalid_argument "Io_page.get cannot allocate a -ve number of pages")
+  else if n = 0
+  then Array1.create char c_layout 0
   else
     try alloc_pages n with _ ->
     Gc.compact ();


### PR DESCRIPTION
It's convenient to allow 0-size buffers to be allocated to
avoid special-cases elsewhere in the code.

Signed-off-by: David Scott dave.scott@eu.citrix.com
