### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/lib/stub_alloc_pages.c
+++ b/lib/stub_alloc_pages.c
@@ -33,7 +33,7 @@
 
 #define PAGE_SIZE 4096
 #include <stdlib.h>
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
io-page-1.1.0 and git master fail with:
In file included from lib/stub_alloc_pages.c:37:0:
/usr/include/malloc.h:3:2: error: #error "<malloc.h> has been replaced by <stdlib.h>"

On FreeBSD we better not include malloc.h then.

This is tested on FreeBSD-CURRENT from 1st January 2014, ocaml 4.01.00
on amd64 using FreeBSD clang version 3.3 (tags/RELEASE_33/final 183502) 20130610

fixes issue #9 reported yesterday by myself
