### PR TITLE
Cleanups to Io_page interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* Make Io_page.t type private.
+  Otherwise, any old array of bytes can be used as an Io_page.t.
+
 1.2.0 (21-Nov-2014):
 * Add `Io_page.get_buf` which allocates an Io_page
   and immediately turns it into a Cstruct that spans the

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -56,24 +56,6 @@ val to_cstruct : t -> buf
 (** [to_cstruct t] generates a {!Cstruct.t} that covers the entire Io_page. *)
 
 val to_string : t -> string
-
-val get_order : int -> t
-(** [get_order i] is [get (1 lsl i)]. *)
-
-val pages : int -> t list
-(** [pages n] allocates a memory block of [n] pages and return the the
-    list of pages allocated. *)
-
-val pages_order : int -> t list
-(** [pages_order i] is [pages (1 lsl i)]. *)
-
-val length : t -> int
-(** [length t] is the size of [t], in bytes. *)
-
-val to_cstruct : t -> buf
-(** [to_cstruct t] generates a {!Cstruct.t} that covers the entire Io_page. *)
-
-val to_string : t -> string
 (** [to_string t] will allocate a fresh {!string} and copy the contents of [t]
     into the string. *)
 

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -22,7 +22,7 @@
 type buf = Cstruct.t
 (** Type of a C buffer (in this case, a Cstruct) *)
 
-type t = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type t = private (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 (** Type of memory blocks. *)
 
 val get : int -> t

--- a/lib_test/portable.ml
+++ b/lib_test/portable.ml
@@ -1,5 +1,4 @@
 open OUnit
-module I = Io_page
 
 external get_addr : Io_page.t -> int64 = "caml_get_addr"
 

--- a/lib_test/portable.mli
+++ b/lib_test/portable.mli
@@ -1,1 +1,0 @@
-module I : V1.IO_PAGE


### PR DESCRIPTION
The makes the Io_page.t type private so that you can't treat any byte array as an IO page.

It also removes some duplicated definitions and removes the test of `IO_PAGE` from Mirage (which we can then delete - see https://github.com/mirage/mirage/issues/343).