### PR TITLE
Add of_cstruct_exn and page_size

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Add of_cstruct_exn as a safe way to turn a cstruct back into an Io_page.t.
+
 1.3.0 (26-Jan-2015):
 * Make `Io_page.t` type private. Otherwise, any old array of bytes
   can be used as an `Io_page.t`. (#14)

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 * Add of_cstruct_exn as a safe way to turn a cstruct back into an Io_page.t.
+* Expose page_size constant in interface.
 
 1.3.0 (26-Jan-2015):
 * Make `Io_page.t` type private. Otherwise, any old array of bytes

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -57,6 +57,16 @@ let round_to_page_size n = ((n + page_size - 1) lsr 12) lsl 12
 
 let to_cstruct t = Cstruct.of_bigarray t
 
+exception Buffer_is_not_page_aligned
+exception Buffer_not_multiple_of_page_size
+
+let of_cstruct_exn x =
+  let ba = Cstruct.to_bigarray x in
+  (* TODO: should check [ba] is page-aligned instead, but that requires C code. *)
+  if x.Cstruct.off <> 0 then raise Buffer_is_not_page_aligned;
+  if Array1.dim ba land (page_size - 1) <> 0 then raise Buffer_not_multiple_of_page_size;
+  ba
+
 let to_string t =
   let result = Bytes.create (length t) in
   for i = 0 to length t - 1 do

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -25,6 +25,9 @@ type buf = Cstruct.t
 type t = private (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 (** Type of memory blocks. *)
 
+val page_size : int
+(** Size of one page of memory in bytes. *)
+
 val get : int -> t
 (** [get n] allocates and returns a memory block of [n] pages. If
     there is not enough memory, an [Out_of_memory] exception is

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -55,6 +55,12 @@ val length : t -> int
 val to_cstruct : t -> buf
 (** [to_cstruct t] generates a {!Cstruct.t} that covers the entire Io_page. *)
 
+val of_cstruct_exn : buf -> t
+(** [of_cstruct t] converts a page-aligned buffer back to an Io_page.
+ * It raises an exception if the cstruct is not page aligned or not a whole number
+ * of pages in length.
+ * TODO: currently assumes the underlying Bigarray is page aligned. *)
+
 val to_string : t -> string
 (** [to_string t] will allocate a fresh {!string} and copy the contents of [t]
     into the string. *)

--- a/opam
+++ b/opam
@@ -3,7 +3,6 @@ maintainer:   "anil@recoil.org"
 homepage:     "https://github.com/mirage/io-page"
 dev-repo:     "https://github.com/mirage/io-page.git"
 bug-reports:  "https://github.com/mirage/io-page/issues"
-version: "1.1.2"
 authors: [
   "Anil Madhavapeddy"
   "Dave Scott"
@@ -18,7 +17,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "io-page"]
 depends: [
   "ocamlfind"
-  "cstruct" {>="1.0.1"}
+  "cstruct" {>="1.1.0"}
   "ounit" {test}
 ]
 available: [ocaml-version >= "4.00.0"]


### PR DESCRIPTION
We often pass around cstructs and only require them to be page-aligned
in the comments. Now that Io_page.t is private, we need a (safe) way to
convert back to Io_page when necessary.