### PR TITLE
Only log an out-of-memory warning after Gc fails

### DIFF
--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -24,17 +24,18 @@ let page_size = 1 lsl 12
 
 let length t = Array1.dim t
 
-external alloc_pages: int -> t = "caml_alloc_pages"
+external alloc_pages: bool -> int -> t = "caml_alloc_pages"
 
 let get n =
   if n < 0
   then raise (Invalid_argument "Io_page.get cannot allocate a -ve number of pages")
   else if n = 0
   then Array1.create char c_layout 0
-  else
-    try alloc_pages n with _ ->
+  else (
+    try alloc_pages false n with Out_of_memory ->
     Gc.compact ();
-    try alloc_pages n with _ -> raise Out_of_memory
+    alloc_pages true n
+  )
 
 let get_order order = get (1 lsl order)
 


### PR DESCRIPTION
Before, we printed e.g. `memalign(4096, 4096) failed` if we couldn't allocate a page, even if the only reason was that we needed to GC first.

Note that if we're also out of OCaml heap space then we might not be able to print the warning at all. However, we still raise `Out_of_memory` in that case.

See: https://github.com/mirage/mirage-tcpip/issues/33