### PR TITLE
only use `opam config var prefix` if dependencies are not present

### DIFF
--- a/postconf.ml
+++ b/postconf.ml
@@ -28,7 +28,8 @@ let () =
 
   let xen_cflags =
     if !xen then
-      check_output "env PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig pkg-config --static mirage-xen-ocaml --cflags"
+      try check_output "pkg-config --static mirage-xen-ocaml --cflags"
+      with _ -> check_output "env PKG_CONFIG_PATH=`opam config var prefix`/lib/pkgconfig pkg-config --static mirage-xen-ocaml --cflags"
     else "xen_not_enabled" in
 
   Buffer.add_string b (Printf.sprintf "XEN_CFLAGS=%S\n" xen_cflags);


### PR DESCRIPTION
This allows building without the `opam` command line tool installed as long as pkgconfig dependencies are already available (as is the case with `opam2nix`).
