### PR TITLE
Windows: _aligned_malloc memory should not be passed to free

### DIFF
--- a/lib/stub_alloc_pages.c
+++ b/lib/stub_alloc_pages.c
@@ -58,7 +58,14 @@ caml_alloc_pages(value did_gc, value n_pages)
   void* block = _xmalloc(len, PAGE_SIZE);
   if (block == NULL) {
 #elif _WIN32
-  void *block = _aligned_malloc(len, PAGE_SIZE);
+  /* NB we can't use _aligned_malloc because we can't get OCaml to
+     finalize with _aligned_free. Regular free() will not work. */
+  static int printed_warning = 0;
+  if (!printed_warning) {
+    printed_warning = 1;
+    printk("WARNING: Io_page on Windows doesn't guarantee alignment\n");
+  }
+  void *block = malloc(len);
   if (block == NULL) {
 #else
   void* block = NULL;


### PR DESCRIPTION
Windows requires memory from _aligned_malloc to be passed to _aligned_free.
If free is called instead then the process crashes.

Unfortunately since an Io_page.t is a bigarray, we have to use the OCaml
builtin finalizer which will either (a) do nothing; or (b) call free().

Since none of the Windows-compatible libraries actually require alignment
yet, this patch prevents the crash by printing a warning message and
returning unaligned memory.

Mitigates #30

Signed-off-by: David Scott <dave@recoil.org>