### PR TITLE
Rename caml_ to mirage_

### DIFF
--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -25,9 +25,9 @@ let page_alignment = 4096
 
 let length t = Array1.dim t
 
-external alloc_pages: bool -> int -> t = "caml_alloc_pages"
+external alloc_pages: bool -> int -> t = "mirage_alloc_pages"
 
-external c_get_addr : t -> nativeint = "caml_get_addr"
+external c_get_addr : t -> nativeint = "mirage_get_addr"
 
 let get_addr t = c_get_addr t
 

--- a/lib/stub_alloc_pages.c
+++ b/lib/stub_alloc_pages.c
@@ -47,7 +47,7 @@
    call free() whenever all sub-bigarrays are unreachable.
  */
 CAMLprim value
-caml_alloc_pages(value did_gc, value n_pages)
+mirage_alloc_pages(value did_gc, value n_pages)
 {
   CAMLparam2(did_gc, n_pages);
   size_t len = Int_val(n_pages) * PAGE_SIZE;

--- a/lib/stub_get_addr.c
+++ b/lib/stub_get_addr.c
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 
 CAMLprim value
-caml_get_addr(value page)
+mirage_get_addr(value page)
 {
   CAMLparam1(page);
   CAMLlocal1(nativeint);


### PR DESCRIPTION
@yallop points out that caml_ is reserved for OCaml.

Signed-off-by: David Scott <dave@recoil.org>