### PR TITLE
io-page-xen: prepend onto PKG_CONFIG_PATH

### DIFF
--- a/io-page-xen.opam
+++ b/io-page-xen.opam
@@ -11,8 +11,8 @@ authors: [
 ]
 tags: ["org:mirage"]
 build: [
-  [ "jbuilder" "subst"] {pinned}
-  [ "env" "PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "jbuilder" "build" "-p" name "-j" jobs ]
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "jbuilder" "subst"] {pinned}
+  [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 
 depends: [

--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -6,6 +6,13 @@ let write_sexp fn sexp =
   Out_channel.write_all fn ~data:(Sexp.to_string sexp)
 
 let () =
+  (* Extend the pkg-config path rather than overwriting it.
+     See #25 *)
+  let prepend = try Unix.getenv "OPAM_PKG_CONFIG_PATH" ^ ":" with _ -> "" in
+  let onto = try Unix.getenv "PKG_CONFIG_PATH" with _ -> "" in
+  let combined = prepend ^ onto in
+  if not(String.equal combined "") then Unix.putenv "PKG_CONFIG_PATH" combined;
+
   C.main ~name:"mirage-xen-ocaml" (fun c ->
     let default : C.Pkg_config.package_conf =
       { libs   = []


### PR DESCRIPTION
This uses the name `OPAM_PKG_CONFIG_PATH` suggested in #25, and combines this with the real `PKG_CONFIG_PATH` in the `lib/config/discover.ml` program.

Signed-off-by: David Scott <dave@recoil.org>