### PR TITLE
drop bytes dependency

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -2,7 +2,7 @@
  ((name io_page)
   (public_name io-page)
   (modules (Io_page))
-  (libraries (cstruct bytes))
+  (libraries (cstruct))
   (wrapped false)
 ))
 


### PR DESCRIPTION
it's only needed for <4.02 and we can't build on <4.02 anyway