### PR TITLE
Prepare release 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ env:
   - DISTRO="debian-stable" OCAML_VERSION=4.04 PACKAGE="io-page-xen"
   - DISTRO="alpine"        OCAML_VERSION=4.06 PACKAGE="io-page"
   - DISTRO="alpine"        OCAML_VERSION=4.07 PACKAGE="io-page"
+  - DISTRO="alpine"        OCAML_VERSION=4.08 PACKAGE="io-page"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v2.3.0 (2019-06-20)
+* Hook in the JavaScript stubs to dune (#55 @jonludlam)
+* Remove unnecessary dependency on `configurator`, which pulled
+  in a jbuilder dependency. We have used `dune.configurator` since the
+  v2.1.0 release (@avsm)
+
 ## v2.2.0 (2019-04-09)
 * Use bigarray_compat (#56, @TheLortex)
 

--- a/io-page-unix.opam
+++ b/io-page-unix.opam
@@ -7,9 +7,8 @@ homepage: "https://github.com/mirage/io-page"
 bug-reports: "https://github.com/mirage/io-page/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "io-page"
-  "dune" {build & >= "1.0"}
-  "configurator" {build}
+  "dune"
+  "io-page" {=version}
   "cstruct" {>= "2.0.0"}
   "ounit" {with-test}
 ]

--- a/io-page-xen.opam
+++ b/io-page-xen.opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mirage/io-page/issues"
 doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "io-page"
-  "dune" {build & >= "1.0"}
+  "dune"
+  "io-page" {=version}
   "cstruct" {>= "2.0.0"}
   "mirage-xen-ocaml"
 ]

--- a/io-page.opam
+++ b/io-page.opam
@@ -8,9 +8,9 @@ bug-reports: "https://github.com/mirage/io-page/issues"
 doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.0"}
+  "dune"
   "cstruct" {>= "2.0.0"}
-  "bigarray-compat" {>= "1.0.0"}
+  "bigarray-compat"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/lib/dune
+++ b/lib/dune
@@ -3,6 +3,7 @@
  (public_name io-page)
  (modules Io_page)
  (libraries cstruct bigarray-compat)
+ (js_of_ocaml (javascript_files io-page.js))
  (wrapped false))
 
 (library

--- a/lib/io-page.js
+++ b/lib/io-page.js
@@ -14,12 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-//Provides: caml_alloc_pages
+//Provides: mirage_alloc_pages
 //Requires: caml_ba_create_from
 //Requires: caml_ba_views
 //Requires: caml_ba_init_views
 //Requires: caml_ba_get_size
-function caml_alloc_pages(npages) {
+function mirage_alloc_pages(did_gc, npages) {
   caml_ba_init_views();
   var dims = [ npages * 4096 ];
   var size = caml_ba_get_size(dims);


### PR DESCRIPTION
* Hook in the JavaScript stubs to dune (#55 @jonludlam)
* Remove unnecessary dependency on `configurator`, which pulled
  in a jbuilder dependency. We have used `dune.configurator` since the
  v2.1.0 release (@avsm)

Fixes #55 which is now rebased