### PR TITLE
opam: depend on dune-configurator

### DIFF
--- a/io-page.opam
+++ b/io-page.opam
@@ -9,6 +9,7 @@ doc: "https://mirage.github.io/io-page/"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune"
+  "dune-configurator"
   "cstruct" {>= "2.0.0"}
   "bigarray-compat"
   "ounit" {with-test}


### PR DESCRIPTION
noticed while looking at build failures for https://github.com/mirage/ocaml-vchan/pull/135