### PR TITLE
Upgrade the C layout of io-page according to MirageOS 3/4

### DIFF
--- a/.test-mirage.sh
+++ b/.test-mirage.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+opam install -y mirage
+(cd unikernel && mirage configure -t hvt && make depends && mirage build && mirage clean && cd ..) || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - PINS="io-page.dev:."
   matrix:
   - DISTRO="debian-stable" OCAML_VERSION=4.08 PACKAGE="io-page"
-  - DISTRO="alpine"        OCAML_VERSION=4.08 PACKAGE="io-page" TESTS=false POST_INSTALL_HOOK=./.test-mirage.sh
+  - DISTRO="debian-stable" OCAML_VERSION=4.08 PACKAGE="io-page" TESTS=false POST_INSTALL_HOOK=./.test-mirage.sh
   - DISTRO="alpine"        OCAML_VERSION=4.09 PACKAGE="io-page"
   - DISTRO="alpine"        OCAML_VERSION=4.10 PACKAGE="io-page"
   - DISTRO="alpine"        OCAML_VERSION=4.11 PACKAGE="io-page"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
   global:
   - PINS="io-page.dev:."
   matrix:
-  - DISTRO="debian-stable" OCAML_VERSION=4.04 PACKAGE="io-page"
-  - DISTRO="alpine"        OCAML_VERSION=4.06 PACKAGE="io-page"
-  - DISTRO="alpine"        OCAML_VERSION=4.07 PACKAGE="io-page"
-  - DISTRO="alpine"        OCAML_VERSION=4.08 PACKAGE="io-page"
+  - DISTRO="debian-stable" OCAML_VERSION=4.08 PACKAGE="io-page"
+  - DISTRO="alpine"        OCAML_VERSION=4.08 PACKAGE="io-page" TESTS=false POST_INSTALL_HOOK=./.test-mirage.sh
+  - DISTRO="alpine"        OCAML_VERSION=4.09 PACKAGE="io-page"
+  - DISTRO="alpine"        OCAML_VERSION=4.10 PACKAGE="io-page"
+  - DISTRO="alpine"        OCAML_VERSION=4.11 PACKAGE="io-page"

--- a/META.io-page.template
+++ b/META.io-page.template
@@ -1,0 +1,3 @@
+# DUNE_GEN
+
+freestanding_linkopts = "-l:libiopage_freestanding_stubs.a"

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 2.6)
 (name io-page)

--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -1,0 +1,23 @@
+PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+
+EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)
+
+.PHONY: all clean
+all: libiopage_freestanding_stubs.a
+
+ifeq ($(EXISTS), 1)
+libiopage_freestanding_stubs.a:
+	touch $@
+else
+CC ?= cc
+FREESTANDING_CFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags ocaml-freestanding)
+CFLAGS := $(FREESTANDING_CFLAGS)
+
+OBJS=stub_alloc_pages.o stub_get_addr.o
+
+libiopage_freestanding_stubs.a: $(OBJS)
+	$(AR) r $@ $^
+endif
+
+clean:
+	$(RM) $(OBJS) libtcpip_freestanding_stubs.a

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -1,0 +1,14 @@
+(copy_files# ../lib/*.c)
+
+(rule
+ (deps Makefile stub_alloc_pages.c stub_get_addr.c)
+ (targets libiopage_freestanding_stubs.a)
+ (action
+  (no-infer
+   (progn
+    (run %{make})))))
+
+(install
+ (package io-page)
+ (section lib)
+ (files libiopage_freestanding_stubs.a))

--- a/io-page.opam
+++ b/io-page.opam
@@ -7,6 +7,7 @@ homepage: "https://github.com/mirage/io-page"
 bug-reports: "https://github.com/mirage/io-page/issues"
 doc: "https://mirage.github.io/io-page/"
 depends: [
+  "conf-pkg-config" {build}
   "ocaml" {>= "4.02.3"}
   "dune"
   "cstruct" {>= "2.0.0"}
@@ -21,6 +22,9 @@ build: [
 conflicts: [
   "mirage-xen" {< "6.0.0"}
   "ocaml-freestanding" {< "0.4.1"}
+]
+depopts: [
+  "ocaml-freestanding"
 ]
 dev-repo: "git+https://github.com/mirage/io-page.git"
 synopsis: "Support for efficient handling of I/O memory pages"

--- a/io-page.opam
+++ b/io-page.opam
@@ -18,6 +18,10 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
 dev-repo: "git+https://github.com/mirage/io-page.git"
 synopsis: "Support for efficient handling of I/O memory pages"
 description: """

--- a/lib/dune
+++ b/lib/dune
@@ -6,4 +6,5 @@
   (language c)
   (names stub_alloc_pages stub_get_addr)
   (flags :standard))
- (js_of_ocaml (javascript_files io-page.js)))
+ (js_of_ocaml
+  (javascript_files io-page.js)))

--- a/lib/dune
+++ b/lib/dune
@@ -2,5 +2,8 @@
  (name io_page)
  (public_name io-page)
  (libraries cstruct bigarray-compat)
- (c_names stub_alloc_pages stub_get_addr)
+ (foreign_stubs
+  (language c)
+  (names stub_alloc_pages stub_get_addr)
+  (flags :standard))
  (js_of_ocaml (javascript_files io-page.js)))

--- a/lib/io-page.js
+++ b/lib/io-page.js
@@ -14,12 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-//Provides: mirage_alloc_pages
+//Provides: caml_mirage_iopage_alloc_pages
 //Requires: caml_ba_create_from
 //Requires: caml_ba_views
 //Requires: caml_ba_init_views
 //Requires: caml_ba_get_size
-function mirage_alloc_pages(did_gc, npages) {
+function caml_mirage_iopage_alloc_pages(did_gc, npages) {
   caml_ba_init_views();
   var dims = [ npages * 4096 ];
   var size = caml_ba_get_size(dims);

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -25,9 +25,9 @@ let page_alignment = 4096
 
 let length t = Array1.dim t
 
-external alloc_pages: bool -> int -> t = "mirage_alloc_pages"
+external alloc_pages: bool -> int -> t = "caml_mirage_iopage_alloc_pages"
 
-external c_get_addr : t -> nativeint = "mirage_get_addr"
+external c_get_addr : t -> nativeint = "caml_mirage_iopage_get_addr"
 
 let get_addr t = c_get_addr t
 

--- a/lib/stub_alloc_pages.c
+++ b/lib/stub_alloc_pages.c
@@ -47,7 +47,7 @@
    call free() whenever all sub-bigarrays are unreachable.
  */
 CAMLprim value
-mirage_alloc_pages(value did_gc, value n_pages)
+caml_mirage_iopage_alloc_pages(value did_gc, value n_pages)
 {
   CAMLparam2(did_gc, n_pages);
   size_t len = Int_val(n_pages) * PAGE_SIZE;

--- a/lib/stub_get_addr.c
+++ b/lib/stub_get_addr.c
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 
 CAMLprim value
-mirage_get_addr(value page)
+caml_mirage_iopage_get_addr(value page)
 {
   CAMLparam1(page);
   CAMLlocal1(nativeint);

--- a/unikernel/config.ml
+++ b/unikernel/config.ml
@@ -1,0 +1,9 @@
+open Mirage
+
+let io_page =
+  foreign "Unikernel.Make"
+    (console @-> job)
+
+let () =
+  register "io-page" ~packages:[ package "io-page" ]
+    [ io_page $ default_console ]

--- a/unikernel/unikernel.ml
+++ b/unikernel/unikernel.ml
@@ -1,0 +1,7 @@
+module Make (Console : Mirage_console.S) = struct
+  let log console fmt = Format.kasprintf (Console.log console) fmt
+
+  let start console =
+    let v = Io_page.get_order 15 in
+    log console "addr: %nx." (Io_page.get_addr v)
+end


### PR DESCRIPTION
According to the plan of MirageOS 4 and the current status of `io-page`, this PR proposes to upgrade the project to the usual C layout to be compatible with MirageOS 3 and be ready for MirageOS 4.