### PR TITLE
drop "caml_" prefix from C code

### DIFF
--- a/lib/io-page.js
+++ b/lib/io-page.js
@@ -14,12 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-//Provides: caml_mirage_iopage_alloc_pages
+//Provides: mirage_iopage_alloc_pages
 //Requires: caml_ba_create_from
 //Requires: caml_ba_views
 //Requires: caml_ba_init_views
 //Requires: caml_ba_get_size
-function caml_mirage_iopage_alloc_pages(did_gc, npages) {
+function mirage_iopage_alloc_pages(did_gc, npages) {
   caml_ba_init_views();
   var dims = [ npages * 4096 ];
   var size = caml_ba_get_size(dims);

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -25,9 +25,9 @@ let page_alignment = 4096
 
 let length t = Array1.dim t
 
-external alloc_pages: bool -> int -> t = "caml_mirage_iopage_alloc_pages"
+external alloc_pages: bool -> int -> t = "mirage_iopage_alloc_pages"
 
-external c_get_addr : t -> nativeint = "caml_mirage_iopage_get_addr"
+external c_get_addr : t -> nativeint = "mirage_iopage_get_addr"
 
 let get_addr t = c_get_addr t
 

--- a/lib/stub_alloc_pages.c
+++ b/lib/stub_alloc_pages.c
@@ -47,7 +47,7 @@
    call free() whenever all sub-bigarrays are unreachable.
  */
 CAMLprim value
-caml_mirage_iopage_alloc_pages(value did_gc, value n_pages)
+mirage_iopage_alloc_pages(value did_gc, value n_pages)
 {
   CAMLparam2(did_gc, n_pages);
   size_t len = Int_val(n_pages) * PAGE_SIZE;
@@ -79,20 +79,5 @@ caml_mirage_iopage_alloc_pages(value did_gc, value n_pages)
   /* Explicitly zero the page before returning it */
   memset(block, 0, len);
 
-/* OCaml 4.02 introduced bigarray element type CAML_BA_CHAR,
-   which needs to be used - otherwise type t in io_page.ml
-   is different from the allocated bigarray and equality won't
-   hold.
-   Only since 4.02 there is a <caml/version.h>, thus we cannot
-   include it in order to detect the version of the OCaml runtime.
-   Instead, we use definitions which were introduced by 4.02 - and
-   cross fingers that they'll stay there in the future.
-   Once <4.02 support is removed, we should get rid of this hack.
-   -- hannes, 16th Feb 2015
- */
-#ifdef Caml_ba_kind_val
   CAMLreturn(caml_ba_alloc_dims(CAML_BA_CHAR | CAML_BA_C_LAYOUT | CAML_BA_MANAGED, 1, block, len));
-#else
-  CAMLreturn(caml_ba_alloc_dims(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED, 1, block, len));
-#endif
 }

--- a/lib/stub_get_addr.c
+++ b/lib/stub_get_addr.c
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 
 CAMLprim value
-caml_mirage_iopage_get_addr(value page)
+mirage_iopage_get_addr(value page)
 {
   CAMLparam1(page);
   CAMLlocal1(nativeint);


### PR DESCRIPTION
in addition, this drops < 4.02 support (should be fine).

I'm curious how the `js` code works, given that it does not provide a `mirage_iopage_get_addr` symbol. Any users thereof? Anyone who's knowledgeable with JS to come up with an implementation?