### PR TITLE
Make freestanding compilation possible without OPAM

### DIFF
--- a/freestanding/Makefile
+++ b/freestanding/Makefile
@@ -1,4 +1,6 @@
-PKG_CONFIG_PATH := $(shell opam config var prefix)/lib/pkgconfig
+ifneq (, $(shell command -v opam))
+	PKG_CONFIG_PATH ?= $(shell opam var prefix)/lib/pkgconfig
+endif
 
 EXISTS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists ocaml-freestanding; echo $$?)
 


### PR DESCRIPTION
* Let the user pass PKG_CONFIG_PATH from the outside even if opam is
  present.

* Don't clear PKG_CONFIG_PATH if opam is missing.