### PR TITLE
Skip unnecessary and missing unistd.h for MSVC compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## Pending
+* Skip unnecessary and missing unistd.h for MSVC compiler (@jonahbeckford, #66)
+
 ## v2.4.0 (2021-02-22)
 * Use workspace flags (@TheLortex, #60)
 * Use ocamlformat (@TheLortex, #60)

--- a/lib/stub_alloc_pages.c
+++ b/lib/stub_alloc_pages.c
@@ -24,7 +24,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #define PAGE_SIZE 4096

--- a/lib/stub_get_addr.c
+++ b/lib/stub_get_addr.c
@@ -22,7 +22,9 @@
 
 #include <fcntl.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <stdint.h>
 
 #include <caml/alloc.h>


### PR DESCRIPTION
`unistd.h` is not present in Visual Studio, but it is rarely necessary since other standard headers include much of it.