### PR TITLE
Do not use Cstruct but directly bigarrays

### DIFF
--- a/io-page.opam
+++ b/io-page.opam
@@ -10,7 +10,6 @@ depends: [
   "conf-pkg-config" {build}
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6"}
-  "cstruct" {>= "2.0.0"}
   "ounit" {with-test}
 ]
 build: [
@@ -28,7 +27,6 @@ depopts: [
 dev-repo: "git+https://github.com/mirage/io-page.git"
 synopsis: "Support for efficient handling of I/O memory pages"
 description: """
-IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
-copying the data contained within the page.
+IO pages are page-aligned, using big-arrays.
 """
 x-maintenance-intent: [ "(latest)" ]

--- a/lib/dune
+++ b/lib/dune
@@ -2,10 +2,9 @@
  (name io_page)
  (modules io_page)
  (public_name io-page)
- (libraries cstruct)
  (foreign_stubs
   (language c)
-  (names stub_alloc_pages stub_get_addr)
+  (names stub_alloc_pages stub_get_addr stub_bigstring)
   (flags :standard))
  (js_of_ocaml
   (javascript_files io-page.js)))

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -151,8 +151,8 @@ let blit src srcoff dst dstoff len =
     unsafe_blit_bigstring_to_bigstring src.buffer (src.off+srcoff) dst.buffer
       (dst.off+dstoff) len
 
-external unsafe_blit_string_to_bigstring : string -> int -> buffer -> int -> int -> unit = "caml_blit_string_to_bigstring" [@@noalloc]
-external unsafe_blit_bigstring_to_bytes : buffer -> int -> Bytes.t -> int -> int -> unit = "caml_blit_bigstring_to_string" [@@noalloc]
+external unsafe_blit_string_to_bigstring : string -> int -> buffer -> int -> int -> unit = "mirage_iopage_blit_string_to_bigstring" [@@noalloc]
+external unsafe_blit_bigstring_to_bytes : buffer -> int -> Bytes.t -> int -> int -> unit = "mirage_iopage_blit_bigstring_to_string" [@@noalloc]
 
 let string_blit src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || dstoff < 0 || String.length src - srcoff < len then

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -141,16 +141,7 @@ let pages_order order = pages (1 lsl order)
 
 let round_to_page_size n = ((n + page_size - 1) lsr 12) lsl 12
 
-let to_string t =
-  let len = length t in
-  let result = Bytes.create len in
-  for i = 0 to len - 1 do
-    Bytes.set result i t.buffer.{i}
-  done;
-  Bytes.unsafe_to_string result
-
 external unsafe_blit_bigstring_to_bigstring : buffer -> int -> buffer -> int -> int -> unit = "mirage_iopage_blit_bigstring_to_bigstring" [@@noalloc]
-
 let blit src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || src.len - srcoff < len then
     invalid_arg "blit with source indexes"
@@ -178,6 +169,12 @@ let blit_to_bytes src srcoff dst dstoff len =
     invalid_arg "blit with dest indexes"
   else
     unsafe_blit_bigstring_to_bytes src.buffer (src.off+srcoff) dst 0 len
+
+let to_string t =
+  let len = length t in
+  let dst = Bytes.create len in
+  unsafe_blit_bigstring_to_bytes t.buffer t.off dst 0 len ;
+  Bytes.unsafe_to_string dst
 
 let check_bounds t len =
   len >= 0 && Bigarray.Array1.dim t.buffer >= len

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -14,82 +14,215 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Bigarray
+type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t 
 
-type t = (char, int8_unsigned_elt, c_layout) Array1.t
+type t = {
+  buffer: buffer;
+  off: int;
+  len: int;
+}
 
-type buf = Cstruct.t
-
-let page_size = 1 lsl 12
+let page_size = 1 lsl 12 (* 4096 *)
+(* Alignement is now constrained by the allocation call.
+   For pages created with of_bigarray and sub, the alignment constraint
+   and the size of the buffer are checked. *)
 let page_alignment = 4096
 
-let length t = Array1.dim t
+let length b = b.len
 
-external alloc_pages: bool -> int -> t = "mirage_iopage_alloc_pages"
+external alloc_pages: bool -> int -> buffer = "mirage_iopage_alloc_pages"
 
-external c_get_addr : t -> nativeint = "mirage_iopage_get_addr"
+external c_get_addr : buffer -> nativeint = "mirage_iopage_get_addr"
 
-let get_addr t = c_get_addr t
+let get_addr t = Nativeint.(add (c_get_addr t.buffer) (of_int t.off))
 
 let get_page t = Nativeint.(div (get_addr t) (of_int page_size))
 
-let get n =
+external check_alignment_bigstring : buffer -> int -> int -> bool = "mirage_iopage_check_alignment_bigstring"
+
+exception Buffer_is_not_page_aligned
+exception Buffer_not_multiple_of_page_size
+
+let assert_alignement_and_size ba =
+  if not(check_alignment_bigstring ba 0 page_alignment) then
+    raise Buffer_is_not_page_aligned;
+  let dim = Bigarray.Array1.dim ba in
+  if dim land (page_size - 1) <> 0 then raise Buffer_not_multiple_of_page_size;
+  ()
+
+let get ?(n=1) () =
   if n < 0
   then raise (Invalid_argument "Io_page.get cannot allocate a -ve number of pages")
-  else if n = 0
-  then Array1.create char c_layout 0
   else (
-    try alloc_pages false n with Out_of_memory ->
+    try
+      {buffer=alloc_pages false n; off=0; len=page_size}
+    with Out_of_memory ->
     Gc.compact ();
-    alloc_pages true n
+    {buffer=alloc_pages true n; off=0; len=page_size}
   )
 
-let get_order order = get (1 lsl order)
+let unsafe_of_bigarray ?(off=0) ?len ba =
+  let dim = Bigarray.Array1.dim ba in
+  let len =
+    match len with
+    | None     -> dim - off
+    | Some len -> len in
+  if off < 0 || len < 0 || off + len < 0 || off + len > dim then invalid_arg "of_bigarray"
+  else {buffer=ba; off; len}
 
-let to_pages t =
-  assert(length t mod page_size = 0);
+let of_bigarray ?(off=0) ?len ba =
+  assert_alignement_and_size ba ;
+  unsafe_of_bigarray ~off ?len ba
+
+let unsafe_sub t off len =
+  (* from https://github.com/mirage/ocaml-cstruct/pull/245
+
+     Cstruct.sub should select what a programmer intuitively expects a
+     sub-cstruct to be. I imagine holding out my hands, with the left
+     representing the start offset and the right the end. I think of a
+     sub-cstruct as any span within this range. If I move my left hand only to
+     the right (new_start >= t.off), and my right hand only to the left
+     (new_end <= old_end), and they don't cross (new_start <= new_end), then I
+     feel sure the result will be a valid sub-cstruct. And if I violate any one
+     of these constraints (e.g. moving my left hand further left), then I feel
+     sure that the result wouldn't be something I'd consider to be a sub-cstruct.
+
+     Wrapping considerations in modular arithmetic:
+
+     Note that if x is non-negative, and x + y wraps, then x + y must be
+     negative. This is easy to see with modular arithmetic because if y is
+     negative then the two arguments will cancel to some degree the result
+     cannot be further from zero than one of the arguments. If y is positive
+     then x + y can wrap, but even max_int + max_int doesn't wrap all the way to
+     zero.
+
+     The three possibly-wrapping operations are:
+
+     new_start = t.off + off. t.off is non-negative so if this wraps then
+     new_start will be negative and will fail the new_start >= t.off test.
+
+     new_end = new_start + len. The above test ensures that new_start is
+     non-negative in any successful return. So if this wraps then new_end will
+     be negative and will fail the new_start <= new_end test.
+
+     old_end = t.off + t.len. This uses only the existing trusted values. It
+     could only wrap if the underlying bigarray had a negative length!  *)
+  let new_start = t.off + off in
+  let new_end = new_start + len in
+  let old_end = t.off + t.len in
+  if new_start >= t.off && new_end <= old_end && new_start <= new_end then
+    { t with off = new_start ; len }
+  else
+    invalid_arg ("sub fails: "^string_of_int(new_start)^" >= "^string_of_int(t.off)^" && "^string_of_int(new_end)^" <= "^string_of_int(old_end)^" && "^string_of_int(new_start)^" <= "^string_of_int(new_end))
+
+let sub t off len =
+  assert_alignement_and_size t.buffer ;
+  unsafe_sub t off len
+
+let unsafe_to_pages t =
   let rec loop off acc =
     if off < (length t)
-    then loop (off + page_size) (Array1.sub t off page_size :: acc)
+    then loop (off + page_size) (sub t off page_size :: acc)
     else acc in
   List.rev (loop 0 [])
 
+let to_pages t =
+  assert_alignement_and_size t.buffer ;
+  unsafe_to_pages t
+
+let get_order order = get ~n:(1 lsl order) ()
+
 let pages n =
   let rec inner acc n =
-    if n > 0 then inner ((get 1)::acc) (n-1) else acc
+    if n > 0 then inner ((get ~n:1 ())::acc) (n-1) else acc
   in inner [] n
 
 let pages_order order = pages (1 lsl order)
 
 let round_to_page_size n = ((n + page_size - 1) lsr 12) lsl 12
 
-let to_cstruct t = Cstruct.of_bigarray t
-
-exception Buffer_is_not_page_aligned
-exception Buffer_not_multiple_of_page_size
-
-let of_cstruct_exn x =
-  let ba = Cstruct.to_bigarray x in
-  if not(Cstruct.check_alignment x page_alignment) then
-    raise Buffer_is_not_page_aligned;
-  if Array1.dim ba land (page_size - 1) <> 0 then raise Buffer_not_multiple_of_page_size;
-  ba
-
 let to_string t =
-  let result = Bytes.create (length t) in
-  for i = 0 to length t - 1 do
-    Bytes.set result i t.{i}
+  let len = length t in
+  let result = Bytes.create len in
+  for i = 0 to len - 1 do
+    Bytes.set result i t.buffer.{i}
   done;
-  Bytes.to_string result
+  Bytes.unsafe_to_string result
 
-let get_buf ?(n=1) () =
-  to_cstruct (get n)
+external unsafe_blit_bigstring_to_bigstring : buffer -> int -> buffer -> int -> int -> unit = "mirage_iopage_blit_bigstring_to_bigstring" [@@noalloc]
 
-let blit src dest = Array1.blit src dest
+let blit src srcoff dst dstoff len =
+  if len < 0 || srcoff < 0 || src.len - srcoff < len then
+    invalid_arg "blit with source indexes"
+  else if dstoff < 0 || dst.len - dstoff < len then
+    invalid_arg "blit with dest indexes"
+  else
+    unsafe_blit_bigstring_to_bigstring src.buffer (src.off+srcoff) dst.buffer
+      (dst.off+dstoff) len
 
 (* TODO: this is extremely inefficient.  Should use a ocp-endian
    blit rather than a byte-by-byte *)
 let string_blit src srcoff dst dstoff len =
+  (* TODO: check for buffer length or rename as unsafe? *)
   for i = 0 to len - 1 do
-    dst.{i+dstoff} <- src.[i+srcoff]
+    dst.buffer.{i+dst.off+dstoff} <- src.[i+srcoff]
   done
+
+let blit_to_bytes src srcoff dst dstoff len =
+  (* TODO: check for bytes length or rename as unsafe? *)
+  for i = 0 to len - 1 do
+    Bytes.set dst (i+dstoff) src.buffer.{i+src.off+srcoff}
+  done
+
+let check_bounds t len =
+  len >= 0 && Bigarray.Array1.dim t.buffer >= len
+
+let shift t amount =
+  let off = t.off + amount in
+  let len = t.len - amount in
+  if amount < 0 || amount > t.len || not (check_bounds t (off+len)) then
+    invalid_arg "shift amount"
+  else { t with off; len }
+
+
+type uint8 = int
+type uint16 = int
+type uint32 = int32
+
+let set_uint8 t i c =
+  if i >= (length t) || i < 0 then invalid_arg "set_uint8 invalid bound"
+  else Bigarray.Array1.set t.buffer i (Char.unsafe_chr c)
+
+let get_uint8 t i =
+  if i >= (length t) || i < 0 then invalid_arg "get_uint8 invalid bound"
+  else Char.code (Bigarray.Array1.get t.buffer i)
+
+external ba_set_int16 : buffer -> int -> uint16 -> unit = "%caml_bigstring_set16u"
+external ba_get_int16 : buffer -> int -> uint16 = "%caml_bigstring_get16u"
+external swap16 : int -> int = "%bswap16"
+
+let swap = Sys.big_endian
+
+let set_le_uint16 t i c =
+  if i > (length t) - 2 || i < 0 then invalid_arg "set_le_uint16 invalid bound"
+  else ba_set_int16 t.buffer i (if swap then swap16 c else c) [@@inline]
+
+let get_le_uint16 t i =
+  if i > (length t) - 2 || i < 0 then invalid_arg "get_le_uint16 invalid bound"
+  else
+    let r = ba_get_int16 t.buffer i in
+    if swap then swap16 r else r [@@inline]
+
+external ba_set_int32 : buffer -> int -> uint32 -> unit = "%caml_bigstring_set32u"
+external ba_get_int32 : buffer -> int -> uint32 = "%caml_bigstring_get32u"
+external swap32 : int32 -> int32 = "%bswap_int32"
+
+let set_le_uint32 t i c =
+  if i > (length t) - 4 || i < 0 then invalid_arg "set_le_uint32 invalid bound"
+  else ba_set_int32 t.buffer i (if swap then swap32 c else c) [@@inline]
+
+let get_le_uint32 t i =
+  if i > (length t) - 4 || i < 0 then invalid_arg "get_le_uint32 invalid bound"
+  else
+    let r = ba_get_int32 t.buffer i in
+    if swap then swap32 r else r [@@inline]

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -190,6 +190,7 @@ let shift t amount =
 type uint8 = int
 type uint16 = int
 type uint32 = int32
+type uint64 = int64
 
 let set_uint8 t i c =
   if i >= (length t) || i < 0 then invalid_arg "set_uint8 invalid bound"
@@ -228,3 +229,17 @@ let get_le_uint32 t i =
   else
     let r = ba_get_int32 t.buffer (t.off+i) in
     if swap then swap32 r else r [@@inline]
+
+external ba_set_int64 : buffer -> int -> uint64 -> unit = "%caml_bigstring_set64u"
+external ba_get_int64 : buffer -> int -> uint64 = "%caml_bigstring_get64u"
+external swap64 : int64 -> int64 = "%bswap_int64"
+
+let set_le_uint64 t i c =
+  if i > t.len - 8 || i < 0 then invalid_arg "set_le_uint64 invalid bound"
+  else ba_set_int64 t.buffer (t.off+i) (if swap then swap64 c else c) [@@inline]
+
+let get_le_uint64 t i =
+  if i > t.len - 8 || i < 0 then invalid_arg "get_le_uint64 invalid bound"
+  else
+    let r = ba_get_int64 t.buffer (t.off+i) in
+    if swap then swap64 r else r [@@inline]

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -160,19 +160,24 @@ let blit src srcoff dst dstoff len =
     unsafe_blit_bigstring_to_bigstring src.buffer (src.off+srcoff) dst.buffer
       (dst.off+dstoff) len
 
-(* TODO: this is extremely inefficient.  Should use a ocp-endian
-   blit rather than a byte-by-byte *)
+external unsafe_blit_string_to_bigstring : string -> int -> buffer -> int -> int -> unit = "caml_blit_string_to_bigstring" [@@noalloc]
+external unsafe_blit_bigstring_to_bytes : buffer -> int -> Bytes.t -> int -> int -> unit = "caml_blit_bigstring_to_string" [@@noalloc]
+
 let string_blit src srcoff dst dstoff len =
-  (* TODO: check for buffer length or rename as unsafe? *)
-  for i = 0 to len - 1 do
-    dst.buffer.{i+dst.off+dstoff} <- src.[i+srcoff]
-  done
+  if len < 0 || srcoff < 0 || dstoff < 0 || String.length src - srcoff < len then
+    invalid_arg "blit with source indexes"
+  else if dst.len - dstoff < len then
+    invalid_arg "blit with dest indexes"
+  else
+    unsafe_blit_string_to_bigstring src srcoff dst.buffer (dst.off+dstoff) len
 
 let blit_to_bytes src srcoff dst dstoff len =
-  (* TODO: check for bytes length or rename as unsafe? *)
-  for i = 0 to len - 1 do
-    Bytes.set dst (i+dstoff) src.buffer.{i+src.off+srcoff}
-  done
+  if len < 0 || srcoff < 0 || src.len - srcoff < len then
+    invalid_arg "blit with source indexes"
+  else if (Bytes.length dst) - dstoff < len then
+    invalid_arg "blit with dest indexes"
+  else
+    unsafe_blit_bigstring_to_bytes src.buffer (src.off+srcoff) dst 0 len
 
 let check_bounds t len =
   len >= 0 && Bigarray.Array1.dim t.buffer >= len
@@ -205,12 +210,12 @@ let swap = Sys.big_endian
 
 let set_le_uint16 t i c =
   if i > (length t) - 2 || i < 0 then invalid_arg "set_le_uint16 invalid bound"
-  else ba_set_int16 t.buffer i (if swap then swap16 c else c) [@@inline]
+  else ba_set_int16 t.buffer (t.off+i) (if swap then swap16 c else c) [@@inline]
 
 let get_le_uint16 t i =
   if i > (length t) - 2 || i < 0 then invalid_arg "get_le_uint16 invalid bound"
   else
-    let r = ba_get_int16 t.buffer i in
+    let r = ba_get_int16 t.buffer (t.off+i) in
     if swap then swap16 r else r [@@inline]
 
 external ba_set_int32 : buffer -> int -> uint32 -> unit = "%caml_bigstring_set32u"
@@ -219,10 +224,10 @@ external swap32 : int32 -> int32 = "%bswap_int32"
 
 let set_le_uint32 t i c =
   if i > (length t) - 4 || i < 0 then invalid_arg "set_le_uint32 invalid bound"
-  else ba_set_int32 t.buffer i (if swap then swap32 c else c) [@@inline]
+  else ba_set_int32 t.buffer (t.off+i) (if swap then swap32 c else c) [@@inline]
 
 let get_le_uint32 t i =
   if i > (length t) - 4 || i < 0 then invalid_arg "get_le_uint32 invalid bound"
   else
-    let r = ba_get_int32 t.buffer i in
+    let r = ba_get_int32 t.buffer (t.off+i) in
     if swap then swap32 r else r [@@inline]

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -50,15 +50,15 @@ let assert_alignement_and_size ba =
   if dim land (page_size - 1) <> 0 then raise Buffer_not_multiple_of_page_size;
   ()
 
-let get ?(n=1) () =
+let get n =
   if n < 0
   then raise (Invalid_argument "Io_page.get cannot allocate a -ve number of pages")
   else (
     try
-      {buffer=alloc_pages false n; off=0; len=page_size}
+      {buffer=alloc_pages false n; off=0; len=n*page_size}
     with Out_of_memory ->
     Gc.compact ();
-    {buffer=alloc_pages true n; off=0; len=page_size}
+    {buffer=alloc_pages true n; off=0; len=n*page_size}
   )
 
 let unsafe_of_bigarray ?(off=0) ?len ba =
@@ -130,11 +130,11 @@ let to_pages t =
   assert_alignement_and_size t.buffer ;
   unsafe_to_pages t
 
-let get_order order = get ~n:(1 lsl order) ()
+let get_order order = get (1 lsl order)
 
 let pages n =
   let rec inner acc n =
-    if n > 0 then inner ((get ~n:1 ())::acc) (n-1) else acc
+    if n > 0 then inner (get 1::acc) (n-1) else acc
   in inner [] n
 
 let pages_order order = pages (1 lsl order)

--- a/lib/io_page.ml
+++ b/lib/io_page.ml
@@ -168,7 +168,7 @@ let blit_to_bytes src srcoff dst dstoff len =
   else if (Bytes.length dst) - dstoff < len then
     invalid_arg "blit with dest indexes"
   else
-    unsafe_blit_bigstring_to_bytes src.buffer (src.off+srcoff) dst 0 len
+    unsafe_blit_bigstring_to_bytes src.buffer (src.off+srcoff) dst dstoff len
 
 let to_string t =
   let len = length t in

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -104,6 +104,7 @@ val shift: t -> int -> t
 type uint8 = int
 type uint16 = int
 type uint32 = int32
+type uint64 = int64
 
 val set_uint8: t -> int -> uint8 -> unit
 val get_uint8: t -> int -> uint8
@@ -111,5 +112,7 @@ val set_le_uint16: t -> int -> uint16 -> unit
 val get_le_uint16: t -> int -> uint16
 val set_le_uint32: t -> int -> uint32 -> unit
 val get_le_uint32: t -> int -> uint32
+val set_le_uint64: t -> int -> uint64 -> unit
+val get_le_uint64: t -> int -> uint64
 
 (* val shift: t -> int -> t *)

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -17,12 +17,13 @@
 
 (** Memory allocation. *)
 
-(** Memory allocation interface. *)
+type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t 
 
-type buf = Cstruct.t
-(** Type of a C buffer (in this case, a Cstruct) *)
-
-type t = private (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type t = {
+  buffer: buffer;
+  off: int;
+  len: int;
+}
 (** Type of memory blocks. *)
 
 val page_size : int
@@ -35,19 +36,27 @@ val get_addr : t -> nativeint
 val get_page : t -> nativeint
 (** [get_page t] returns the page offset (get_addr t) mod page_size, starting at 0 .*)
 
-val get : int -> t
+val get : ?n:int -> unit -> t
 (** [get n] allocates and returns a memory block of [n] pages. If
     there is not enough memory, an [Out_of_memory] exception is
-    raised.  Note that this may be a recoverable situation, since
+    raised. Note that this may be a recoverable situation, since
     this function allocates memory from a page-aligned pool, whereas
     the OCaml garbage collector will be running in its own heap that
     may have spare memory despite the [Out_of_memory] being raised
     from this function call. *)
 
-val get_buf : ?n:int -> unit -> buf
-(** [get_buf n] allocates and returns a memory block of [n] pages,
-    represented as a {!Cstruct.t}. If there is not enough memory,
-    an [Out_of_memory] exception is raised. *)
+exception Buffer_is_not_page_aligned
+exception Buffer_not_multiple_of_page_size
+
+val unsafe_of_bigarray : ?off:int -> ?len:int -> buffer -> t
+val of_bigarray : ?off:int -> ?len:int -> buffer -> t
+
+val unsafe_sub: t -> int -> int -> t
+val sub: t -> int -> int -> t
+
+val to_pages : t -> t list
+(** [to_pages t] is a list of [size] memory blocks of one page each,
+    where [size] is the size of [t] in pages. *)
 
 val get_order : int -> t
 (** [get_order i] is [get (1 lsl i)]. *)
@@ -62,36 +71,45 @@ val pages_order : int -> t list
 val length : t -> int
 (** [length t] is the size of [t], in bytes. *)
 
-val to_cstruct : t -> buf
-(** [to_cstruct t] generates a {!Cstruct.t} that covers the entire Io_page. *)
-
-exception Buffer_is_not_page_aligned
-exception Buffer_not_multiple_of_page_size
-
-val of_cstruct_exn : buf -> t
-(** [of_cstruct t] converts a page-aligned buffer back to an Io_page.
-  It raises {!Buffer_is_not_page_aligned} if [t] is not page aligned or
-  {!Buffer_not_multiple_of_page_size} if [t] is not a whole number
-  of pages in length.
-  TODO: currently assumes the underlying Bigarray is page aligned. *)
-
 val to_string : t -> string
 (** [to_string t] will allocate a fresh {!string} and copy the contents of [t]
     into the string. *)
-
-val to_pages : t -> t list
-(** [to_pages t] is a list of [size] memory blocks of one page each,
-    where [size] is the size of [t] in pages. *)
 
 val string_blit : string -> int -> t -> int -> int -> unit
 (** [string_blit src srcoff dst dstoff len] copies [len] bytes from
     string [src], starting at byte number [srcoff], to memory block
     [dst], starting at byte number dstoff. *)
 
-val blit : t -> t -> unit
-(** [blit t1 t2] is the same as {!Bigarray.Array1.blit}. *)
+val blit_to_bytes : t -> int -> bytes -> int -> int -> unit
+
+val blit: t -> int -> t -> int -> int -> unit
+(** [blit src srcoff dst dstoff len] copies [len] characters from
+    cstruct [src], starting at index [srcoff], to cstruct [dst],
+    starting at index [dstoff]. It works correctly even if [src] and
+    [dst] are the same string, and the source and destination
+    intervals overlap.
+
+    @raise Invalid_argument if [srcoff] and [len] do not designate a
+    valid segment of [src], or if [dstoff] and [len] do not designate
+    a valid segment of [dst]. *)
 
 val round_to_page_size : int -> int
 (** [round_to_page_size n] returns the number of bytes that will be
     allocated for storing [n] bytes in memory *)
 
+val shift: t -> int -> t
+(** [shift cstr len] is [{ cstr with off=t.off+len; len=t.len-len }]
+    @raise Invalid_argument if the offset exceeds cstruct length. *)
+
+type uint8 = int
+type uint16 = int
+type uint32 = int32
+
+val set_uint8: t -> int -> uint8 -> unit
+val get_uint8: t -> int -> uint8
+val set_le_uint16: t -> int -> uint16 -> unit
+val get_le_uint16: t -> int -> uint16
+val set_le_uint32: t -> int -> uint32 -> unit
+val get_le_uint32: t -> int -> uint32
+
+(* val shift: t -> int -> t *)

--- a/lib/io_page.mli
+++ b/lib/io_page.mli
@@ -36,7 +36,7 @@ val get_addr : t -> nativeint
 val get_page : t -> nativeint
 (** [get_page t] returns the page offset (get_addr t) mod page_size, starting at 0 .*)
 
-val get : ?n:int -> unit -> t
+val get : int -> t
 (** [get n] allocates and returns a memory block of [n] pages. If
     there is not enough memory, an [Out_of_memory] exception is
     raised. Note that this may be a recoverable situation, since

--- a/lib/stub_bigstring.c
+++ b/lib/stub_bigstring.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2012 Pierre Chambart
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <caml/mlvalues.h>
+#include <caml/bigarray.h>
+#include <string.h>
+
+CAMLprim value
+mirage_iopage_check_alignment_bigstring(value val_buf, value val_ofs, value val_alignment)
+{
+  uint64_t address = (uint64_t) ((char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs));
+  uintnat alignment = Unsigned_long_val(val_alignment);
+  return Val_bool(address % alignment == 0);
+}
+
+CAMLprim value
+mirage_iopage_blit_bigstring_to_bigstring(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
+{
+  memmove((char*)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
+         (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
+         Long_val(val_len));
+  return Val_unit;
+}
+
+CAMLprim value
+mirage_iopage_fill_bigstring(value val_buf, value val_ofs, value val_len, value val_byte)
+{
+  memset((char*)Caml_ba_data_val(val_buf) + Long_val(val_ofs),
+         Int_val(val_byte),
+         Long_val(val_len));
+  return Val_unit;
+}

--- a/lib/stub_bigstring.c
+++ b/lib/stub_bigstring.c
@@ -36,6 +36,25 @@ mirage_iopage_blit_bigstring_to_bigstring(value val_buf1, value val_ofs1, value 
   return Val_unit;
 }
 
+
+CAMLprim value
+mirage_iopage_blit_bigstring_to_string(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
+{
+  memcpy(Bytes_val(val_buf2) + Long_val(val_ofs2),
+         (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
+         Long_val(val_len));
+  return Val_unit;
+}
+
+CAMLprim value
+mirage_iopage_blit_string_to_bigstring(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
+{
+  memcpy((char*)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
+         String_val(val_buf1) + Long_val(val_ofs1),
+         Long_val(val_len));
+  return Val_unit;
+}
+
 CAMLprim value
 mirage_iopage_fill_bigstring(value val_buf, value val_ofs, value val_len, value val_byte)
 {

--- a/lib_test/portable.ml
+++ b/lib_test/portable.ml
@@ -2,7 +2,7 @@ open OUnit
 
 let test_alignment () =
   for _ = 0 to 1000 do
-    let page = Io_page.get ~n:1 () in
+    let page = Io_page.get 1 in
     let addr = Io_page.get_addr page in
     assert_equal ~printer:Nativeint.to_string 0n Nativeint.(rem addr 4096n)
   done

--- a/lib_test/portable.ml
+++ b/lib_test/portable.ml
@@ -2,7 +2,7 @@ open OUnit
 
 let test_alignment () =
   for _ = 0 to 1000 do
-    let page = Io_page.get 1 in
+    let page = Io_page.get ~n:1 () in
     let addr = Io_page.get_addr page in
     assert_equal ~printer:Nativeint.to_string 0n Nativeint.(rem addr 4096n)
   done


### PR DESCRIPTION
This PR is related to #71 and removes the Cstruct interface by using bigarrays directly. To help minimize the work of resolving the break, I added Cstruct functions that were used in other libraries (e.g. shared-ring, mirage-xen), because I observed that most of the time the calls were like:
```Ocaml
let page = <function to get io_page> |> Io_page.to_cstruct in
Cstruct.xxx page ;
```
The interface is therefore similar to that of the current Cstruct, with a bigarray, an offset and a length :)
The main constraint is to keep the bigarray page-aligned, this constraint is respected when calling `get` and is checked when calling `of_bigarray`. I see that I also check in `sub`, but as the argument is an Io_page I don't think that's really useful...
As far as getter/setter are concerned, I've only kept the LE forms because, to my knowledge, that's what's used with Xen.

Any feedback will be appreciated :)
Best